### PR TITLE
[worker] Expose prometheus metrics

### DIFF
--- a/opencti-worker/src/config.yml.sample
+++ b/opencti-worker/src/config.yml.sample
@@ -5,3 +5,5 @@ opencti:
 
 worker:
   log_level: 'info'
+  expose_metrics: false
+  metrics_port: 9095

--- a/opencti-worker/src/requirements.txt
+++ b/opencti-worker/src/requirements.txt
@@ -1,2 +1,3 @@
 pycti==5.0.3
 black==20.8b1
+prometheus-client~=0.11.0


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add metrics for worker operations
* Expose the metrics on an HTTP endpoint (so that they can be scraped by Prometheus)

### Related issues

N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...